### PR TITLE
Add links to flatpak host on flathub

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -22,6 +22,7 @@ description: geteduroam is a project to simplify the process of connecting to ed
 <li><details class="download-button-linux"><summary>Linux</summary>
 	<ul>
 		<li><a href="https://github.com/geteduroam/linux-app/releases">⎋ GitHub</a>
+		<li><a href="https://flathub.org/apps/app.eduroam.geteduroam">Flathub</a>
 	</ul>
 </details>
 </ul>

--- a/content/enduser/connecting.md
+++ b/content/enduser/connecting.md
@@ -14,6 +14,7 @@ These instructions apply for users in institutions that are eduroam IdPs and use
 		* [AMD/Intel (amd64)](https://dl.eduroam.app/windows/amd64/geteduroam.exe)
 		* [ARM (arm64)](https://dl.eduroam.app/windows/arm64/geteduroam.exe)
 	* Linux
+		* [Flathub](https://flathub.org/apps/app.eduroam.geteduroam)
 		* [GitHub](https://github.com/geteduroam/linux-app/releases)
 2. Start the app and select your institution
 3. Depending on whether your institution has enrolled in geteduroam, you will either


### PR DESCRIPTION
This PR adds links to the flatpak hosted on flathub under the Linux instructions.