### PR TITLE
Update BookRepo and BookEditPath in config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -42,7 +42,7 @@ BookSection = '*'
 
 # Set source repository location.
 # Used for 'Last Modified' and 'Edit this page' links.
-BookRepo = 'https://github.com/geteduroam/documentation.git'
+BookRepo = 'https://github.com/geteduroam/geteduroam.github.io'
 
 # Specifies commit portion of the link to the page's last modified commit hash for 'doc' page
 # type.
@@ -54,7 +54,7 @@ BookCommitPath = 'commit'
 # Enable 'Edit this page' links for 'doc' page type.
 # Disabled by default. Uncomment to enable. Requires 'BookRepo' param.
 # Path must point to the site directory.
-BookEditPath = 'edit/master/exampleSite'
+BookEditPath = 'edit/main'
 
 # (Optional, default January 2, 2006) Configure the date format used on the pages
 # - In git information


### PR DESCRIPTION
This pull request updates repository references and edit paths in the `config.toml` configuration file to align with the current GitHub repository structure. These changes ensure that "Edit this page" and "Last Modified" links point to the correct repository and branch.

Repository reference updates:

* Changed `BookRepo` to point to `https://github.com/geteduroam/geteduroam.github.io` instead of the old documentation repository.

Edit path updates:

* Updated `BookEditPath` to use `edit/main` instead of `edit/master/exampleSite`, reflecting the move to the `main` branch and new repository structure.